### PR TITLE
Rename minio namespace to observatorium-minio

### DIFF
--- a/doc/operator/deploy-operator.md
+++ b/doc/operator/deploy-operator.md
@@ -18,7 +18,6 @@ In order to ease the installation of Observatorium, an operator is available.
 
 #### Create Namespaces
 ```shell script
-kubectl create namespace observatorium-minio
 kubectl create namespace observatorium
 ```
 
@@ -26,10 +25,11 @@ kubectl create namespace observatorium
 #### S3 storage endpoint and secret
 For **testing purposes** you may use [minio](https://github.com/minio/minio) as describe below.
 ```shell script
-kubectl apply -f https://raw.githubusercontent.com/observatorium/deployments/master/environments/dev/manifests/minio-secret.yaml
-kubectl apply -f https://raw.githubusercontent.com/observatorium/deployments/master/environments/dev/manifests/minio-pvc.yaml
-kubectl apply -f https://raw.githubusercontent.com/observatorium/deployments/master/environments/dev/manifests/minio-deployment.yaml
-kubectl apply -f https://raw.githubusercontent.com/observatorium/deployments/master/environments/dev/manifests/minio-service.yaml
+kubectl create namespace observatorium-minio
+kubectl apply -f https://raw.githubusercontent.com/observatorium/configuration/master/environments/dev/manifests/minio-secret.yaml
+kubectl apply -f https://raw.githubusercontent.com/observatorium/configuration/master/environments/dev/manifests/minio-pvc.yaml
+kubectl apply -f https://raw.githubusercontent.com/observatorium/configuration/master/environments/dev/manifests/minio-deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/observatorium/configuration/master/environments/dev/manifests/minio-service.yaml
 ```
 
 ### Deployment

--- a/doc/operator/deploy-operator.md
+++ b/doc/operator/deploy-operator.md
@@ -18,7 +18,7 @@ In order to ease the installation of Observatorium, an operator is available.
 
 #### Create Namespaces
 ```shell script
-kubectl create namespace minio
+kubectl create namespace observatorium-minio
 kubectl create namespace observatorium
 ```
 

--- a/environments/dev/main.jsonnet
+++ b/environments/dev/main.jsonnet
@@ -89,7 +89,7 @@ local obs = (import '../base/observatorium.jsonnet') + {
 
 local minio = (import '../../components/minio.libsonnet') + {
   config:: {
-    namespace: 'minio',
+    namespace: 'observatorium-minio',
     bucketSecretNamespace: obs.config.namespace,
   },
 };

--- a/environments/dev/manifests/minio-deployment.yaml
+++ b/environments/dev/manifests/minio-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minio
-  namespace: minio
+  namespace: observatorium-minio
 spec:
   selector:
     matchLabels:

--- a/environments/dev/manifests/minio-pvc.yaml
+++ b/environments/dev/manifests/minio-pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: minio
   name: minio
-  namespace: minio
+  namespace: observatorium-minio
 spec:
   accessModes:
   - ReadWriteOnce

--- a/environments/dev/manifests/minio-secret.yaml
+++ b/environments/dev/manifests/minio-secret.yaml
@@ -8,7 +8,7 @@ stringData:
     type: s3
     config:
       bucket: thanos
-      endpoint: minio.minio.svc.cluster.local:9000
+      endpoint: minio.observatorium-minio.svc.cluster.local:9000
       insecure: true
       access_key: minio
       secret_key: minio123

--- a/environments/dev/manifests/minio-service.yaml
+++ b/environments/dev/manifests/minio-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: minio
-  namespace: minio
+  namespace: observatorium-minio
 spec:
   ports:
   - port: 9000

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -16,8 +16,8 @@ kind() {
 deploy() {
     $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
     $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
-    $KUBECTL create ns minio || true
     $KUBECTL create ns dex || true
+    $KUBECTL create ns observatorium-minio || true
     $KUBECTL create ns observatorium || true
     $KUBECTL apply -f environments/dev/manifests/
 }
@@ -51,8 +51,8 @@ deploy_operator() {
     ./kind load docker-image quay.io/observatorium/observatorium-operator:latest
     $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
     $KUBECTL apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
-    $KUBECTL create ns minio || true
     $KUBECTL create ns dex || true
+    $KUBECTL create ns observatorium-minio || true
     $KUBECTL create ns observatorium || true
     $KUBECTL apply -f environments/dev/manifests/minio-secret.yaml
     $KUBECTL apply -f environments/dev/manifests/minio-pvc.yaml
@@ -93,7 +93,7 @@ delete_cr() {
 }
 
 run_test() {
-    $KUBECTL wait --for=condition=available --timeout=10m -n minio deploy/minio || ($KUBECTL get pods --all-namespaces && exit 1)
+    $KUBECTL wait --for=condition=available --timeout=10m -n observatorium-minio deploy/minio || ($KUBECTL get pods --all-namespaces && exit 1)
     $KUBECTL wait --for=condition=available --timeout=10m -n observatorium deploy/observatorium-xyz-thanos-query || ($KUBECTL get pods --all-namespaces && exit 1)
 
     $KUBECTL apply -f tests/manifests/observatorium-up.yaml


### PR DESCRIPTION
While deploying Observatorium to an actual cluster, I find it quite weird to have a random minio namespace, I'd rather prefix it with Observatorium, to make it more obvious to others.

/cc @kakkoyun @squat @rollandf 