### PR TITLE
README: update links and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-# Configuration
+# Observatorium Deployments
+[![Build Status](https://circleci.com/gh/observatorium/deployments.svg?style=svg)](https://circleci.com/gh/observatorium/deployments)
 
-This repository contains the configuration for the Observatorium instances that the team runs.
-[Observatorium Operator Documentation](./doc/operator/deploy-operator.md)
+This repository contains configuration for deploying the Observatorium platform.
+Currently, this includes:
 
-[![Build Status](https://circleci.com/gh/observatorium/configuration.svg?style=svg)](https://circleci.com/gh/observatorium/configuration)
+0. jsonnet files for advanced customization of the platform;
+0. example Kubernetes manifests to directly deploy Observatorium; and
+0. example configuration for deploying Observatorium via the Observatorium Operator.
+
+For more information on the operator, see the [Observatorium Operator documentation](./doc/operator/deploy-operator.md).
 


### PR DESCRIPTION
This commit fixes the links in the README to reflect the new project
URL and adds some more details to the description.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @observatorium/maintainers  @nmagnezi 