### PR TITLE
Fix external prefix

### DIFF
--- a/components/observatorium.libsonnet
+++ b/components/observatorium.libsonnet
@@ -160,22 +160,6 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       ],
       replicaLabels: obs.config.replicaLabels,
     },
-    deployment+: {
-      spec+: {
-        template+: {
-          spec+: {
-            containers: [
-              if c.name == 'thanos-query' then c {
-                args+: [
-                  '--web.external-prefix=.',
-                ],
-              } else c
-              for c in super.containers
-            ],
-          },
-        },
-      },
-    },
   },
 
   queryCache:: (import 'cortex-query-frontend.libsonnet') + {

--- a/environments/base/manifests/thanos-query-deployment.yaml
+++ b/environments/base/manifests/thanos-query-deployment.yaml
@@ -52,7 +52,6 @@ spec:
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-store-shard-0.observatorium.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
         - --query.timeout=15m
-        - --web.external-prefix=.
         image: quay.io/thanos/thanos:master-2020-05-24-079ad427
         livenessProbe:
           failureThreshold: 4

--- a/environments/dev/manifests/thanos-query-deployment.yaml
+++ b/environments/dev/manifests/thanos-query-deployment.yaml
@@ -52,7 +52,6 @@ spec:
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-store-shard-0.observatorium.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
         - --query.timeout=15m
-        - --web.external-prefix=.
         image: quay.io/thanos/thanos:master-2020-05-24-079ad427
         livenessProbe:
           failureThreshold: 4


### PR DESCRIPTION
Thanks to thanos-io/thanos#2714, all links in
the frontend are now relative. Unfortunately, that means that using
`--external-prefix=.` turns `static/x` into `.static/x`, which doesn't
exist. We'll fix this here now and then ensure we sanitize this upstream
in Thanos.

cc @observatorium/maintainers 