### PR TITLE
Enable metrics svc for loki ingester component

### DIFF
--- a/components/loki.libsonnet
+++ b/components/loki.libsonnet
@@ -629,6 +629,6 @@ local k = (import 'ksonnet/ksonnet.beta.4/k.libsonnet');
   } + {
     [normalizedName(name) + '-http-service']: newHttpService(name)
     for name in std.objectFields(loki.components)
-    if std.member(['distributor', 'query_frontend', 'querier'], name)
+    if std.member(['distributor', 'query_frontend', 'querier', 'ingester'], name)
   },
 }

--- a/environments/base/manifests/loki-ingester-http-service.yaml
+++ b/environments/base/manifests/loki-ingester-http-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: master-815c475
+  name: observatorium-xyz-loki-ingester-http
+  namespace: observatorium
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/environments/dev/manifests/loki-ingester-http-service.yaml
+++ b/environments/dev/manifests/loki-ingester-http-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: master-815c475
+  name: observatorium-xyz-loki-ingester-http
+  namespace: observatorium
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium


### PR DESCRIPTION
This PR enables per default the HTTP svc for Loki's ingester component. By this prometheus can scrape this endpoint for metrics.
