### PR TITLE
[loki] Bump version master-815c475 to 1.6.0

### DIFF
--- a/components/loki.libsonnet
+++ b/components/loki.libsonnet
@@ -203,7 +203,7 @@ local k = (import 'ksonnet/ksonnet.beta.4/k.libsonnet');
   defaultConfig+:: {
     local grpcServerMaxMsgSize = 104857600,
     local querierConcurrency = 32,
-    local indexPeriodHours = 168,
+    local indexPeriodHours = 24,
 
     auth_enabled: true,
     chunk_store_config: {

--- a/environments/base/default-config.libsonnet
+++ b/environments/base/default-config.libsonnet
@@ -167,7 +167,7 @@
 
   loki: {
     local lokiConfig = self,
-    version: 'master-815c475',
+    version: '1.6.0',
     image: 'docker.io/grafana/loki:' + lokiConfig.version,
     objectStorageConfig: defaultConfig.objectStorageConfig.loki,
     replicas: {

--- a/environments/base/manifests/loki-config-map.yaml
+++ b/environments/base/manifests/loki-config-map.yaml
@@ -48,7 +48,7 @@ data:
       "max_query_parallelism": 32
       "max_streams_per_user": 0
       "reject_old_samples": true
-      "reject_old_samples_max_age": "168h"
+      "reject_old_samples_max_age": "24h"
     "memberlist":
       "abort_if_cluster_join_fails": false
       "bind_port": 7946
@@ -74,7 +74,7 @@ data:
       "configs":
       - "from": "2018-04-15"
         "index":
-          "period": "168h"
+          "period": "24h"
           "prefix": "loki_index_"
         "object_store": "s3"
         "schema": "v11"
@@ -113,6 +113,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/environments/base/manifests/loki-distributor-deployment.yaml
+++ b/environments/base/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:master-815c475
+        image: docker.io/grafana/loki:1.6.0
         name: observatorium-xyz-loki-distributor
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-distributor-grpc-service.yaml
+++ b/environments/base/manifests/loki-distributor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-distributor-http-service.yaml
+++ b/environments/base/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-gossip-ring.yaml
+++ b/environments/base/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-ingester-deployment.yaml
+++ b/environments/base/manifests/loki-ingester-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:master-815c475
+        image: docker.io/grafana/loki:1.6.0
         name: observatorium-xyz-loki-ingester
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-ingester-grpc-service.yaml
+++ b/environments/base/manifests/loki-ingester-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-ingester-http-service.yaml
+++ b/environments/base/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-querier-deployment.yaml
+++ b/environments/base/manifests/loki-querier-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:master-815c475
+        image: docker.io/grafana/loki:1.6.0
         name: observatorium-xyz-loki-querier
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-querier-grpc-service.yaml
+++ b/environments/base/manifests/loki-querier-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-querier-http-service.yaml
+++ b/environments/base/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-query-frontend-deployment.yaml
+++ b/environments/base/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -39,7 +39,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:master-815c475
+        image: docker.io/grafana/loki:1.6.0
         name: observatorium-xyz-loki-query-frontend
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-query-frontend-grpc-service.yaml
+++ b/environments/base/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-query-frontend-http-service.yaml
+++ b/environments/base/manifests/loki-query-frontend-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-query-frontend-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-table-manager-deployment.yaml
+++ b/environments/base/manifests/loki-table-manager-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-table-manager
   namespace: observatorium
 spec:
@@ -39,7 +39,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:master-815c475
+        image: docker.io/grafana/loki:1.6.0
         name: observatorium-xyz-loki-table-manager
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-table-manager-grpc-service.yaml
+++ b/environments/base/manifests/loki-table-manager-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-table-manager-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-config-map.yaml
+++ b/environments/dev/manifests/loki-config-map.yaml
@@ -48,7 +48,7 @@ data:
       "max_query_parallelism": 32
       "max_streams_per_user": 0
       "reject_old_samples": true
-      "reject_old_samples_max_age": "168h"
+      "reject_old_samples_max_age": "24h"
     "memberlist":
       "abort_if_cluster_join_fails": false
       "bind_port": 7946
@@ -74,7 +74,7 @@ data:
       "configs":
       - "from": "2018-04-15"
         "index":
-          "period": "168h"
+          "period": "24h"
           "prefix": "loki_index_"
         "object_store": "s3"
         "schema": "v11"
@@ -113,6 +113,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/environments/dev/manifests/loki-distributor-deployment.yaml
+++ b/environments/dev/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:master-815c475
+        image: docker.io/grafana/loki:1.6.0
         name: observatorium-xyz-loki-distributor
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-distributor-grpc-service.yaml
+++ b/environments/dev/manifests/loki-distributor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-distributor-http-service.yaml
+++ b/environments/dev/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-gossip-ring.yaml
+++ b/environments/dev/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-ingester-deployment.yaml
+++ b/environments/dev/manifests/loki-ingester-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:master-815c475
+        image: docker.io/grafana/loki:1.6.0
         name: observatorium-xyz-loki-ingester
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-ingester-grpc-service.yaml
+++ b/environments/dev/manifests/loki-ingester-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-ingester-http-service.yaml
+++ b/environments/dev/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-querier-deployment.yaml
+++ b/environments/dev/manifests/loki-querier-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:master-815c475
+        image: docker.io/grafana/loki:1.6.0
         name: observatorium-xyz-loki-querier
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-querier-grpc-service.yaml
+++ b/environments/dev/manifests/loki-querier-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-querier-http-service.yaml
+++ b/environments/dev/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-query-frontend-deployment.yaml
+++ b/environments/dev/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -39,7 +39,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:master-815c475
+        image: docker.io/grafana/loki:1.6.0
         name: observatorium-xyz-loki-query-frontend
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-query-frontend-grpc-service.yaml
+++ b/environments/dev/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-query-frontend-http-service.yaml
+++ b/environments/dev/manifests/loki-query-frontend-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-query-frontend-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-table-manager-deployment.yaml
+++ b/environments/dev/manifests/loki-table-manager-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-table-manager
   namespace: observatorium
 spec:
@@ -39,7 +39,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:master-815c475
+        image: docker.io/grafana/loki:1.6.0
         name: observatorium-xyz-loki-table-manager
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-table-manager-grpc-service.yaml
+++ b/environments/dev/manifests/loki-table-manager-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-815c475
+    app.kubernetes.io/version: 1.6.0
   name: observatorium-xyz-loki-table-manager-grpc
   namespace: observatorium
 spec:

--- a/example/manifests/observatorium.yaml
+++ b/example/manifests/observatorium.yaml
@@ -57,14 +57,14 @@ spec:
   - hashring: default
     tenants: []
   loki:
-    image: docker.io/grafana/loki:master-815c475
+    image: docker.io/grafana/loki:1.6.0
     replicas:
       distributor: 1
       ingester: 1
       querier: 1
       query_frontend: 1
       table_manager: 1
-    version: master-815c475
+    version: 1.6.0
   objectStorageConfig:
     loki:
       key: endpoint


### PR DESCRIPTION
This PR updates the loki image to include the latest changes in boltdb-shipper released with 1.6.0.

/cc @squat 