### PR TITLE
tests/e2e.sh: fix must-gather for initcontainers

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -126,7 +126,7 @@ must_gather() {
             $KUBECTL -n "$namespace" get pod "$name" -o yaml > "$artifact_dir/$namespace/$name.yaml"
 
             for initContainer in $($KUBECTL -n "$namespace" get po "$name" -o jsonpath='{.spec.initContainers[*].name}') ; do
-                $KUBECTL -n "$namespace" logs "$name" -c "$container" > "$artifact_dir/$namespace/$name-$initContainer.logs"
+                $KUBECTL -n "$namespace" logs "$name" -c "$initContainer" > "$artifact_dir/$namespace/$name-$initContainer.logs"
             done
 
             for container in $($KUBECTL -n "$namespace" get po "$name" -o jsonpath='{.spec.containers[*].name}') ; do


### PR DESCRIPTION
Previously, trying to run must-gather for initcontainers would return
incorrect logs. This commit fixes the function.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @observatorium/maintainers 