### PR TITLE
Fix with{Replicas,Requests,ServiceMonitors} for statefulsets

### DIFF
--- a/components/observatorium.libsonnet
+++ b/components/observatorium.libsonnet
@@ -270,6 +270,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
   loki::
     l +
     l.withMemberList +
+    l.withReplicas +
     l.withVolumeClaimTemplate {
       config+:: {
         local cfg = self,


### PR DESCRIPTION
### Description
This PR addresses a set of hindsights on optional functionality post-introduction of statefulsets for ingesters and queriers. The optional `with{Replicas,Requests,ServiceMonitors}` remain unused in this repository, thus it was an easy mistake ;)