### PR TITLE
Remove container-push job from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,15 +26,6 @@ jobs:
 
 workflows:
   version: 2
-  tagged-master:
-    jobs:
-      - container-push:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only:
-                - master
   test-and-push:
     jobs:
       - build


### PR DESCRIPTION
This hasn't been spotted until we merged the latest PR into master. We don't have any containers to push from this repository anymore and thus builds on master are broken.