### PR TITLE
Make loki optional

### DIFF
--- a/components/observatorium.libsonnet
+++ b/components/observatorium.libsonnet
@@ -326,6 +326,6 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     for name in std.objectFields(obs.apiQuery)
   } + if std.length(obs.config.loki) != 0 then {
     ['loki-' + name]: obs.loki.manifests[name]
-    for name in std.objectFields(obs.loki.manifests)  
+    for name in std.objectFields(obs.loki.manifests)
   } else {},
 }

--- a/components/observatorium.libsonnet
+++ b/components/observatorium.libsonnet
@@ -324,9 +324,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
   } + {
     ['api-thanos-query-' + name]: obs.apiQuery[name]
     for name in std.objectFields(obs.apiQuery)
-  } + {
+  } + if std.length(obs.config.loki) != 0 then {
     ['loki-' + name]: obs.loki.manifests[name]
-    for name in std.objectFields(obs.loki.manifests)
-    if std.length(obs.config.loki) != 0
-  },
+    for name in std.objectFields(obs.loki.manifests)  
+  } else {},
 }


### PR DESCRIPTION
There is an error without loki in CR
```
level=warn ts=2020-09-16T06:37:43.908034Z caller=resource.go:167 msg="sync failed" key=default/observatorium-xyz err="failed to render: failed to evaluate: RUNTIME ERROR: Field does not exist: replicas\n\tvendor/github.com/observatorium/deployments/components/observatorium.libsonnet:280:19-38\tobject <anonymous>\n\tvendor/github.com/observatorium/deployments/components/loki.libsonnet:420:36-53\tthunk from <object <anonymous>>\n\t<std>:1278:24-25\tthunk from <function <anonymous>>\n\t<std>:1278:5-33\tfunction <anonymous>\n\tvendor/github.com/observatorium/deployments/components/loki.libsonnet:420:19-54\tobject <anonymous>\n\t\t\n\t\t\n\tvendor/github.com/observatorium/deployments/components/observatorium.libsonnet:329:34-52\tthunk from <object <anonymous>>\n\t<std>:1278:24-25\tthunk from <function <anonymous>>\n\t<std>:1278:5-33\tfunction <anonymous>\n\t...\n\t\t\n\tobs-operator.jsonnet:52:6-24\tthunk from <object <anonymous>>\n\t<std>:260:27-30\tthunk from <function <anonymous>>\n\t<std>:31:26-27\tthunk from <function <anonymous>>\n\t<std>:31:17-28\tfunction <anonymous>\n\t<std>:260:14-31\tfunction <anonymous>\n\tobs-operator.jsonnet:(41:14)-(52:25)\tobject <anonymous>\n\tmain.jsonnet:1:19-62\tthunk <manifests> from <$>\n\tmain.jsonnet:4:12-21\tobject <anonymous>\n\tDuring manifestation\t\n"
```