### PR TITLE
Fix Make warnings

### DIFF
--- a/.bingo/Variables.mk
+++ b/.bingo/Variables.mk
@@ -45,9 +45,3 @@ $(JSONNETFMT): .bingo/jsonnetfmt.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
 	@echo "(re)installing $(GOBIN)/jsonnetfmt-v0.16.0"
 	@cd .bingo && $(GO) build -modfile=jsonnetfmt.mod -o=$(GOBIN)/jsonnetfmt-v0.16.0 "github.com/google/go-jsonnet/cmd/jsonnetfmt"
-
-GENERATE_TLS_CERT := $(GOBIN)/generate-tls-cert
-$(GENERATE_TLS_CERT): .bingo/generate-tls-cert.mod
-	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
-	@echo "(re)installing $(GOBIN)/generate-tls-cert"
-	@cd .bingo && $(GO) build -modfile=generate-tls-cert.mod -tags tools -o=$(GOBIN)/generate-tls-cert "github.com/observatorium/observatorium/test/tls"

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ generate-cert: $(GENERATE_TLS_CERT) | $(CERT_DIR)
 	cd $(CERT_DIR) && $(GENERATE_TLS_CERT) -server-common-name=observatorium-xyz-observatorium-api.observatorium.svc.cluster.local
 
 # Not managed by Bingo directly, as it requires the -tags tools flag
-GENERATE_TLS_CERT := $(GOBIN)/generate-tls-cert
-$(GENERATE_TLS_CERT): .bingo/generate-tls-cert.mod
+$(GENERATE_TLS_CERT):
 	@echo "(re)installing $(GOBIN)/generate-tls-cert"
 	@cd .bingo && $(GO) build -modfile=generate-tls-cert.mod -tags tools -o=$(GOBIN)/generate-tls-cert "github.com/observatorium/observatorium/test/tls"
 


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

```console
Makefile:28: warning: overriding commands for target `/Users/kakkoyun/Sandbox/deployments/tmp/bin/generate-tls-cert'
.bingo/Variables.mk:51: warning: ignoring old commands for target `/Users/kakkoyun/Sandbox/deployments/tmp/bin/generate-tls-cert'
```