### PR TITLE
Bump loki 1.6.1 to 2.0.0

### DIFF
--- a/components/loki.libsonnet
+++ b/components/loki.libsonnet
@@ -304,6 +304,7 @@ local k = (import 'ksonnet/ksonnet.beta.4/k.libsonnet');
       ingestion_burst_size_mb: 20,
       ingestion_rate_mb: 10,
       ingestion_rate_strategy: 'global',
+      max_cache_freshness_per_query: '10m',
       max_global_streams_per_user: 10000,
       max_query_length: '12000h',
       max_query_parallelism: 32,
@@ -330,9 +331,9 @@ local k = (import 'ksonnet/ksonnet.beta.4/k.libsonnet');
     schema_config: {
       configs: [
         {
-          from: '2018-04-15',
+          from: '2020-10-01',
           index: {
-            period: '%dh' % indexPeriodHours,
+            period: '24h',
             prefix: 'loki_index_',
           },
           object_store: 's3',
@@ -354,7 +355,8 @@ local k = (import 'ksonnet/ksonnet.beta.4/k.libsonnet');
       boltdb_shipper: {
         active_index_directory: '/data/loki/index',
         cache_location: '/data/loki/index_cache',
-        resync_interval: '5s',
+        cache_ttl: '24h',
+        resync_interval: '5m',
         shared_store: 's3',
       },
     },
@@ -489,7 +491,6 @@ local k = (import 'ksonnet/ksonnet.beta.4/k.libsonnet');
         cache_results: true,
         max_retries: 5,
         results_cache: {
-          max_freshness: '10m',
           cache: {
             memcached_client: {
               timeout: '500ms',

--- a/environments/base/default-config.libsonnet
+++ b/environments/base/default-config.libsonnet
@@ -185,7 +185,7 @@
 
   loki+: {
     local lokiConfig = self,
-    version: '1.6.1',
+    version: '2.0.0',
     image: 'docker.io/grafana/loki:' + lokiConfig.version,
     objectStorageConfig: defaultConfig.objectStorageConfig.loki,
     replicas: {

--- a/environments/base/manifests/loki-config-map.yaml
+++ b/environments/base/manifests/loki-config-map.yaml
@@ -43,6 +43,7 @@ data:
       "ingestion_burst_size_mb": 20
       "ingestion_rate_mb": 10
       "ingestion_rate_strategy": "global"
+      "max_cache_freshness_per_query": "10m"
       "max_global_streams_per_user": 10000
       "max_query_length": "12000h"
       "max_query_parallelism": 32
@@ -72,7 +73,7 @@ data:
       "split_queries_by_interval": "30m"
     "schema_config":
       "configs":
-      - "from": "2018-04-15"
+      - "from": "2020-10-01"
         "index":
           "period": "24h"
           "prefix": "loki_index_"
@@ -91,7 +92,8 @@ data:
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"
-        "resync_interval": "5s"
+        "cache_ttl": "24h"
+        "resync_interval": "5m"
         "shared_store": "s3"
   overrides.yaml: '{}'
 kind: ConfigMap
@@ -100,6 +102,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/environments/base/manifests/loki-distributor-deployment.yaml
+++ b/environments/base/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-distributor
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-distributor-grpc-service.yaml
+++ b/environments/base/manifests/loki-distributor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-distributor-http-service.yaml
+++ b/environments/base/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-gossip-ring.yaml
+++ b/environments/base/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-ingester-grpc-service.yaml
+++ b/environments/base/manifests/loki-ingester-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-ingester-http-service.yaml
+++ b/environments/base/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-ingester-statefulset.yaml
+++ b/environments/base/manifests/loki-ingester-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-ingester
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-querier-grpc-service.yaml
+++ b/environments/base/manifests/loki-querier-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-querier-http-service.yaml
+++ b/environments/base/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-querier-statefulset.yaml
+++ b/environments/base/manifests/loki-querier-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-querier
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-query-frontend-deployment.yaml
+++ b/environments/base/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -39,7 +39,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-query-frontend
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-query-frontend-grpc-service.yaml
+++ b/environments/base/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-query-frontend-http-service.yaml
+++ b/environments/base/manifests/loki-query-frontend-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-config-map.yaml
+++ b/environments/dev/manifests/loki-config-map.yaml
@@ -43,6 +43,7 @@ data:
       "ingestion_burst_size_mb": 20
       "ingestion_rate_mb": 10
       "ingestion_rate_strategy": "global"
+      "max_cache_freshness_per_query": "10m"
       "max_global_streams_per_user": 10000
       "max_query_length": "12000h"
       "max_query_parallelism": 32
@@ -72,7 +73,7 @@ data:
       "split_queries_by_interval": "30m"
     "schema_config":
       "configs":
-      - "from": "2018-04-15"
+      - "from": "2020-10-01"
         "index":
           "period": "24h"
           "prefix": "loki_index_"
@@ -91,7 +92,8 @@ data:
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"
-        "resync_interval": "5s"
+        "cache_ttl": "24h"
+        "resync_interval": "5m"
         "shared_store": "s3"
   overrides.yaml: '{}'
 kind: ConfigMap
@@ -100,6 +102,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/environments/dev/manifests/loki-distributor-deployment.yaml
+++ b/environments/dev/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-distributor
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-distributor-grpc-service.yaml
+++ b/environments/dev/manifests/loki-distributor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-distributor-http-service.yaml
+++ b/environments/dev/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-gossip-ring.yaml
+++ b/environments/dev/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-ingester-grpc-service.yaml
+++ b/environments/dev/manifests/loki-ingester-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-ingester-http-service.yaml
+++ b/environments/dev/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-ingester-statefulset.yaml
+++ b/environments/dev/manifests/loki-ingester-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-ingester
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-querier-grpc-service.yaml
+++ b/environments/dev/manifests/loki-querier-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-querier-http-service.yaml
+++ b/environments/dev/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-querier-statefulset.yaml
+++ b/environments/dev/manifests/loki-querier-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-querier
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-query-frontend-deployment.yaml
+++ b/environments/dev/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -39,7 +39,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-query-frontend
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-query-frontend-grpc-service.yaml
+++ b/environments/dev/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-query-frontend-http-service.yaml
+++ b/environments/dev/manifests/loki-query-frontend-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend-http
   namespace: observatorium
 spec:


### PR DESCRIPTION
This is a minor PR with major impact as it is addressing the bump of Loki from 1.6.1 to 2.0.0. Major points addressed by upstream regarding boltdb-shipper:
- https://github.com/grafana/loki/pull/2770
- https://github.com/grafana/loki/pull/2601