### PR TITLE
Add loki compactor component

### DIFF
--- a/components/loki-caches.libsonnet
+++ b/components/loki-caches.libsonnet
@@ -14,7 +14,6 @@ local m = import 'memcached.libsonnet';
 
     enableChuckCache: false,
     enableIndexQueryCache: false,
-    enableIndexWriteCache: false,
     enableResultsCache: false,
 
     commonLabels:: {
@@ -69,26 +68,6 @@ local m = import 'memcached.libsonnet';
       serviceMonitor+: mc.serviceMonitors.index_query_cache,
     } else {},
 
-  indexWriteCache::
-    m +
-    m.withServiceMonitor {
-      config+:: {
-        local cfg = self,
-        name: mc.config.name + '-' + mc.config.commonLabels['app.kubernetes.io/name'] + '-index-write-cache',
-        namespace: mc.config.namespace,
-        commonLabels+:: mc.config.commonLabels {
-          'app.kubernetes.io/component': 'index-write-cache',
-        },
-        version:: mc.config.version,
-        image:: mc.config.image,
-        exporterVersion: mc.config.exporterVersion,
-        exporterImage:: mc.config.exporterImage,
-        replicas: mc.config.replicas.index_write_cache,
-      },
-    } + if std.objectHas(mc.serviceMonitors, 'index_write_cache') then {
-      serviceMonitor+: mc.serviceMonitors.index_write_cache,
-    } else {},
-
   resultsCache::
     m +
     m.withServiceMonitor {
@@ -117,7 +96,6 @@ local m = import 'memcached.libsonnet';
     manifests+:: {
       'chunk-cache-service-monitor': l.chunkCache.serviceMonitor,
       'index-query-cache-service-monitor': l.indexQueryCache.serviceMonitor,
-      'index-write-cache-service-monitor': l.indexWriteCache.serviceMonitor,
       'results-cache-service-monitor': l.resultsCache.serviceMonitor,
     },
   },
@@ -131,10 +109,6 @@ local m = import 'memcached.libsonnet';
     (if mc.config.enableIndexQueryCache then {
        'index-query-cache-service': mc.indexQueryCache.service,
        'index-query-cache-statefulset': mc.indexQueryCache.statefulSet,
-     } else {}) +
-    (if mc.config.enableIndexWriteCache then {
-       'index-write-cache-service': mc.indexWriteCache.service,
-       'index-write-cache-statefulset': mc.indexWriteCache.statefulSet,
      } else {}) +
     (if mc.config.enableResultsCache then {
        'results-cache-service': mc.resultsCache.service,

--- a/components/loki.libsonnet
+++ b/components/loki.libsonnet
@@ -304,6 +304,7 @@ local k = (import 'ksonnet/ksonnet.beta.4/k.libsonnet');
       ingestion_burst_size_mb: 20,
       ingestion_rate_mb: 10,
       ingestion_rate_strategy: 'global',
+      max_cache_freshness_per_query: '10m',
       max_global_streams_per_user: 10000,
       max_query_length: '12000h',
       max_query_parallelism: 32,
@@ -330,9 +331,9 @@ local k = (import 'ksonnet/ksonnet.beta.4/k.libsonnet');
     schema_config: {
       configs: [
         {
-          from: '2018-04-15',
+          from: '2020-10-01',
           index: {
-            period: '%dh' % indexPeriodHours,
+            period: '24h',
             prefix: 'loki_index_',
           },
           object_store: 's3',
@@ -354,7 +355,8 @@ local k = (import 'ksonnet/ksonnet.beta.4/k.libsonnet');
       boltdb_shipper: {
         active_index_directory: '/data/loki/index',
         cache_location: '/data/loki/index_cache',
-        resync_interval: '5s',
+        cache_ttl: '24h',
+        resync_interval: '5m',
         shared_store: 's3',
       },
     },
@@ -489,7 +491,6 @@ local k = (import 'ksonnet/ksonnet.beta.4/k.libsonnet');
         cache_results: true,
         max_retries: 5,
         results_cache: {
-          max_freshness: '10m',
           cache: {
             memcached_client: {
               timeout: '500ms',

--- a/environments/base/default-config.libsonnet
+++ b/environments/base/default-config.libsonnet
@@ -178,7 +178,6 @@
     replicas: {
       chunk_cache: 1,
       index_query_cache: 1,
-      index_write_cache: 1,
       results_cache: 1,
     },
   },
@@ -189,6 +188,7 @@
     image: 'docker.io/grafana/loki:' + lokiConfig.version,
     objectStorageConfig: defaultConfig.objectStorageConfig.loki,
     replicas: {
+      compactor: 1,
       distributor: 1,
       ingester: 1,
       querier: 1,

--- a/environments/base/default-config.libsonnet
+++ b/environments/base/default-config.libsonnet
@@ -185,7 +185,7 @@
 
   loki+: {
     local lokiConfig = self,
-    version: '1.6.1',
+    version: '2.0.0',
     image: 'docker.io/grafana/loki:' + lokiConfig.version,
     objectStorageConfig: defaultConfig.objectStorageConfig.loki,
     replicas: {

--- a/environments/base/manifests/loki-compactor-grpc-service.yaml
+++ b/environments/base/manifests/loki-compactor-grpc-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.0.0
+  name: observatorium-xyz-loki-compactor-grpc
+  namespace: observatorium
+spec:
+  clusterIP: None
+  ports:
+  - name: grcp
+    port: 9095
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/environments/base/manifests/loki-compactor-statefulset.yaml
+++ b/environments/base/manifests/loki-compactor-statefulset.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.0.0
+  name: observatorium-xyz-loki-compactor
+  namespace: observatorium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/instance: observatorium-xyz
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/part-of: observatorium
+  serviceName: observatorium-xyz-loki-compactor-grpc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+    spec:
+      containers:
+      - args:
+        - -target=compactor
+        - -config.file=/etc/loki/config/config.yaml
+        - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
+        - -log.level=error
+        - -s3.url=$(S3_URL)
+        - -s3.force-path-style=true
+        env:
+        - name: S3_URL
+          valueFrom:
+            secretKeyRef:
+              key: endpoint
+              name: loki-objectstorage
+        image: docker.io/grafana/loki:2.0.0
+        name: observatorium-xyz-loki-compactor
+        ports:
+        - containerPort: 3100
+          name: metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3100
+            scheme: HTTP
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/loki/config/
+          name: config
+          readOnly: false
+        - mountPath: /data
+          name: storage
+          readOnly: false
+      volumes:
+      - configMap:
+          name: observatorium-xyz-loki
+        name: config
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+      name: storage
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Mi

--- a/environments/base/manifests/loki-config-map.yaml
+++ b/environments/base/manifests/loki-config-map.yaml
@@ -4,6 +4,10 @@ data:
     "auth_enabled": true
     "chunk_store_config":
       "max_look_back_period": "0s"
+    "compactor":
+      "compaction_interval": "2h"
+      "shared_store": "s3"
+      "working_directory": "/data/loki/compactor"
     "distributor":
       "ring":
         "kvstore":

--- a/environments/base/manifests/loki-config-map.yaml
+++ b/environments/base/manifests/loki-config-map.yaml
@@ -43,6 +43,7 @@ data:
       "ingestion_burst_size_mb": 20
       "ingestion_rate_mb": 10
       "ingestion_rate_strategy": "global"
+      "max_cache_freshness_per_query": "10m"
       "max_global_streams_per_user": 10000
       "max_query_length": "12000h"
       "max_query_parallelism": 32
@@ -72,7 +73,7 @@ data:
       "split_queries_by_interval": "30m"
     "schema_config":
       "configs":
-      - "from": "2018-04-15"
+      - "from": "2020-10-01"
         "index":
           "period": "24h"
           "prefix": "loki_index_"
@@ -91,7 +92,8 @@ data:
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"
-        "resync_interval": "5s"
+        "cache_ttl": "24h"
+        "resync_interval": "5m"
         "shared_store": "s3"
   overrides.yaml: '{}'
 kind: ConfigMap
@@ -100,6 +102,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/environments/base/manifests/loki-distributor-deployment.yaml
+++ b/environments/base/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-distributor
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-distributor-grpc-service.yaml
+++ b/environments/base/manifests/loki-distributor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-distributor-http-service.yaml
+++ b/environments/base/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-gossip-ring.yaml
+++ b/environments/base/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-ingester-grpc-service.yaml
+++ b/environments/base/manifests/loki-ingester-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-ingester-http-service.yaml
+++ b/environments/base/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-ingester-statefulset.yaml
+++ b/environments/base/manifests/loki-ingester-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-ingester
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-querier-grpc-service.yaml
+++ b/environments/base/manifests/loki-querier-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-querier-http-service.yaml
+++ b/environments/base/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-querier-statefulset.yaml
+++ b/environments/base/manifests/loki-querier-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-querier
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-query-frontend-deployment.yaml
+++ b/environments/base/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -39,7 +39,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-query-frontend
         ports:
         - containerPort: 3100

--- a/environments/base/manifests/loki-query-frontend-grpc-service.yaml
+++ b/environments/base/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-query-frontend-http-service.yaml
+++ b/environments/base/manifests/loki-query-frontend-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-compactor-grpc-service.yaml
+++ b/environments/dev/manifests/loki-compactor-grpc-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.0.0
+  name: observatorium-xyz-loki-compactor-grpc
+  namespace: observatorium
+spec:
+  clusterIP: None
+  ports:
+  - name: grcp
+    port: 9095
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/environments/dev/manifests/loki-compactor-statefulset.yaml
+++ b/environments/dev/manifests/loki-compactor-statefulset.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.0.0
+  name: observatorium-xyz-loki-compactor
+  namespace: observatorium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/instance: observatorium-xyz
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/part-of: observatorium
+  serviceName: observatorium-xyz-loki-compactor-grpc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+    spec:
+      containers:
+      - args:
+        - -target=compactor
+        - -config.file=/etc/loki/config/config.yaml
+        - -limits.per-user-override-config=/etc/loki/config/overrides.yaml
+        - -log.level=error
+        - -s3.url=$(S3_URL)
+        - -s3.force-path-style=true
+        env:
+        - name: S3_URL
+          valueFrom:
+            secretKeyRef:
+              key: endpoint
+              name: loki-objectstorage
+        image: docker.io/grafana/loki:2.0.0
+        name: observatorium-xyz-loki-compactor
+        ports:
+        - containerPort: 3100
+          name: metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3100
+            scheme: HTTP
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/loki/config/
+          name: config
+          readOnly: false
+        - mountPath: /data
+          name: storage
+          readOnly: false
+      volumes:
+      - configMap:
+          name: observatorium-xyz-loki
+        name: config
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/instance: observatorium-xyz
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: observatorium
+      name: storage
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Mi

--- a/environments/dev/manifests/loki-config-map.yaml
+++ b/environments/dev/manifests/loki-config-map.yaml
@@ -4,6 +4,10 @@ data:
     "auth_enabled": true
     "chunk_store_config":
       "max_look_back_period": "0s"
+    "compactor":
+      "compaction_interval": "2h"
+      "shared_store": "s3"
+      "working_directory": "/data/loki/compactor"
     "distributor":
       "ring":
         "kvstore":

--- a/environments/dev/manifests/loki-config-map.yaml
+++ b/environments/dev/manifests/loki-config-map.yaml
@@ -43,6 +43,7 @@ data:
       "ingestion_burst_size_mb": 20
       "ingestion_rate_mb": 10
       "ingestion_rate_strategy": "global"
+      "max_cache_freshness_per_query": "10m"
       "max_global_streams_per_user": 10000
       "max_query_length": "12000h"
       "max_query_parallelism": 32
@@ -72,7 +73,7 @@ data:
       "split_queries_by_interval": "30m"
     "schema_config":
       "configs":
-      - "from": "2018-04-15"
+      - "from": "2020-10-01"
         "index":
           "period": "24h"
           "prefix": "loki_index_"
@@ -91,7 +92,8 @@ data:
       "boltdb_shipper":
         "active_index_directory": "/data/loki/index"
         "cache_location": "/data/loki/index_cache"
-        "resync_interval": "5s"
+        "cache_ttl": "24h"
+        "resync_interval": "5m"
         "shared_store": "s3"
   overrides.yaml: '{}'
 kind: ConfigMap
@@ -100,6 +102,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/environments/dev/manifests/loki-distributor-deployment.yaml
+++ b/environments/dev/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-distributor
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-distributor-grpc-service.yaml
+++ b/environments/dev/manifests/loki-distributor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-distributor-http-service.yaml
+++ b/environments/dev/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-gossip-ring.yaml
+++ b/environments/dev/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-ingester-grpc-service.yaml
+++ b/environments/dev/manifests/loki-ingester-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-ingester-http-service.yaml
+++ b/environments/dev/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-ingester-statefulset.yaml
+++ b/environments/dev/manifests/loki-ingester-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-ingester
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-querier-grpc-service.yaml
+++ b/environments/dev/manifests/loki-querier-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-querier-http-service.yaml
+++ b/environments/dev/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-querier-statefulset.yaml
+++ b/environments/dev/manifests/loki-querier-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-querier
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-query-frontend-deployment.yaml
+++ b/environments/dev/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -39,7 +39,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:1.6.1
+        image: docker.io/grafana/loki:2.0.0
         name: observatorium-xyz-loki-query-frontend
         ports:
         - containerPort: 3100

--- a/environments/dev/manifests/loki-query-frontend-grpc-service.yaml
+++ b/environments/dev/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-query-frontend-http-service.yaml
+++ b/environments/dev/manifests/loki-query-frontend-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 1.6.1
+    app.kubernetes.io/version: 2.0.0
   name: observatorium-xyz-loki-query-frontend-http
   namespace: observatorium
 spec:


### PR DESCRIPTION
This PR addresses the missing loki compactor component for a boltdb-shipper only setup. The compactor takes the following duties formerly executed by queriers:
- Deduplicate index entries
- Optimize index file sizes for faster uploads from/downloads to S3 shared storage.

Further important characteristics introduced by the compactor component:
- Makes the index write cache obsolete, as this duty is part of the compactor.
- Makes use of PVCs as a local performance optimization when compacting downloaded indices from S3.

Depends on: #354 (Loki 2.0.0)