### PR TITLE
Add svc for loki compactor metrics

### DIFF
--- a/components/loki.libsonnet
+++ b/components/loki.libsonnet
@@ -705,6 +705,6 @@ local k = (import 'ksonnet/ksonnet.beta.4/k.libsonnet');
   } + {
     [normalizedName(name) + '-http-service']: newHttpService(name)
     for name in std.objectFields(loki.components)
-    if std.member(['distributor', 'query_frontend', 'querier', 'ingester'], name)
+    if std.member(['compactor', 'distributor', 'query_frontend', 'querier', 'ingester'], name)
   },
 }

--- a/environments/base/manifests/loki-compactor-http-service.yaml
+++ b/environments/base/manifests/loki-compactor-http-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.0.0
+  name: observatorium-xyz-loki-compactor-http
+  namespace: observatorium
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium

--- a/environments/dev/manifests/loki-compactor-http-service.yaml
+++ b/environments/dev/manifests/loki-compactor-http-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: 2.0.0
+  name: observatorium-xyz-loki-compactor-http
+  namespace: observatorium
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: observatorium-xyz
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: observatorium


### PR DESCRIPTION
This PR addresses the missing k8s svc resource to enable scraping the Loki compactor component metrics.