### PR TITLE
Bump api v0.1.1-187-g76a4c28 to v0.1.1-192-ge324057

### DIFF
--- a/environments/base/default-config.libsonnet
+++ b/environments/base/default-config.libsonnet
@@ -139,7 +139,7 @@
 
   api: {
     local apiConfig = self,
-    version: 'master-2020-10-27-v0.1.1-187-g76a4c28',
+    version: 'master-2020-11-02-v0.1.1-192-ge324057',
     image: 'quay.io/observatorium/observatorium:' + apiConfig.version,
     replicas: 1,
   },

--- a/environments/base/manifests/api-deployment.yaml
+++ b/environments/base/manifests/api-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-10-27-v0.1.1-187-g76a4c28
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium
 spec:
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: observatorium-api
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-10-27-v0.1.1-187-g76a4c28
+        app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
     spec:
       containers:
       - args:
@@ -41,7 +41,7 @@ spec:
         - --logs.tail.endpoint=http://observatorium-xyz-loki-querier-http.observatorium.svc.cluster.local:3100
         - --logs.write.endpoint=http://observatorium-xyz-loki-distributor-http.observatorium.svc.cluster.local:3100
         - --middleware.rate-limiter.grpc-address=observatorium-xyz-gubernator.observatorium.svc.cluster.local:8081
-        image: quay.io/observatorium/observatorium:master-2020-10-27-v0.1.1-187-g76a4c28
+        image: quay.io/observatorium/observatorium:master-2020-11-02-v0.1.1-192-ge324057
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/base/manifests/api-service.yaml
+++ b/environments/base/manifests/api-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-10-27-v0.1.1-187-g76a4c28
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium
 spec:

--- a/environments/base/manifests/api-serviceAccount.yaml
+++ b/environments/base/manifests/api-serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-10-27-v0.1.1-187-g76a4c28
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium

--- a/environments/dev/manifests/api-configmap.yaml
+++ b/environments/dev/manifests/api-configmap.yaml
@@ -25,6 +25,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-10-27-v0.1.1-187-g76a4c28
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium

--- a/environments/dev/manifests/api-deployment.yaml
+++ b/environments/dev/manifests/api-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-10-27-v0.1.1-187-g76a4c28
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium
 spec:
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/instance: observatorium-xyz
         app.kubernetes.io/name: observatorium-api
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: master-2020-10-27-v0.1.1-187-g76a4c28
+        app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
     spec:
       containers:
       - args:
@@ -43,7 +43,7 @@ spec:
         - --rbac.config=/etc/observatorium/rbac.yaml
         - --tenants.config=/etc/observatorium/tenants.yaml
         - --middleware.rate-limiter.grpc-address=observatorium-xyz-gubernator.observatorium.svc.cluster.local:8081
-        image: quay.io/observatorium/observatorium:master-2020-10-27-v0.1.1-187-g76a4c28
+        image: quay.io/observatorium/observatorium:master-2020-11-02-v0.1.1-192-ge324057
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/dev/manifests/api-secret.yaml
+++ b/environments/dev/manifests/api-secret.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-10-27-v0.1.1-187-g76a4c28
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium
 stringData:

--- a/environments/dev/manifests/api-service.yaml
+++ b/environments/dev/manifests/api-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-10-27-v0.1.1-187-g76a4c28
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/api-serviceAccount.yaml
+++ b/environments/dev/manifests/api-serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: observatorium-api
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: master-2020-10-27-v0.1.1-187-g76a4c28
+    app.kubernetes.io/version: master-2020-11-02-v0.1.1-192-ge324057
   name: observatorium-xyz-observatorium-api
   namespace: observatorium

--- a/tests/main.jsonnet
+++ b/tests/main.jsonnet
@@ -114,12 +114,12 @@ local upLogs = upJob + upJob.withResources + {
       },
     },
     endpointType: 'logs',
-    writeEndpoint: 'http://%s.%s.svc.cluster.local:%d/api/logs/v1/test/api/v1/push' % [
+    writeEndpoint: 'http://%s.%s.svc.cluster.local:%d/api/logs/v1/test/loki/api/v1/push' % [
       obs.api.service.metadata.name,
       obs.api.service.metadata.namespace,
       obs.api.service.spec.ports[1].port,
     ],
-    readEndpoint: 'http://%s.%s.svc.cluster.local:%d/api/logs/v1/test/api/v1/query' % [
+    readEndpoint: 'http://%s.%s.svc.cluster.local:%d/api/logs/v1/test/loki/api/v1/query' % [
       obs.api.service.metadata.name,
       obs.api.service.metadata.namespace,
       obs.api.service.spec.ports[1].port,

--- a/tests/manifests/observatorium-up-logs.yaml
+++ b/tests/manifests/observatorium-up-logs.yaml
@@ -15,8 +15,8 @@ spec:
       containers:
       - args:
         - --endpoint-type=logs
-        - --endpoint-write=http://observatorium-xyz-observatorium-api.observatorium.svc.cluster.local:8080/api/logs/v1/test/api/v1/push
-        - --endpoint-read=http://observatorium-xyz-observatorium-api.observatorium.svc.cluster.local:8080/api/logs/v1/test/api/v1/query
+        - --endpoint-write=http://observatorium-xyz-observatorium-api.observatorium.svc.cluster.local:8080/api/logs/v1/test/loki/api/v1/push
+        - --endpoint-read=http://observatorium-xyz-observatorium-api.observatorium.svc.cluster.local:8080/api/logs/v1/test/loki/api/v1/query
         - --period=1s
         - --duration=2m
         - --name=foo


### PR DESCRIPTION
This PR bumps the API version to include the following fixes:
https://github.com/observatorium/observatorium/compare/76a4c28...e32405763b667866022ca84af5c4c34ffea7700e