### PR TITLE
[loki] Remove obsolete asserts from withConfig

### DIFF
--- a/components/loki.libsonnet
+++ b/components/loki.libsonnet
@@ -412,10 +412,6 @@
       config: error 'must provide loki config',
     },
 
-    assert l.defaultConfig.auth_enabled == true : 'Disabling auth not allowed in multi-tenancy',
-    assert l.defaultConfig.distributor.ring.kvstore.store != 'memberlist' : 'Use withMemberList to configure memberlist store',
-    assert l.defaultConfig.ingester.lifecycler.ring.kvstore.store != 'memberlist' : 'Use withMemberList to configure memberlist store',
-
     defaultConfig+:: l.config.config,
   },
 


### PR DESCRIPTION
This PR remove obsolete asserts in the `withConfig` to allow composability with other loki `with*` functions.