### PR TITLE
[loki] Add withDataReplication to enable replication config

### DIFF
--- a/components/observatorium.libsonnet
+++ b/components/observatorium.libsonnet
@@ -34,6 +34,7 @@ local api = (import 'observatorium/observatorium-api.libsonnet');
     loki +
     loki.withMemberList +
     loki.withReplicas +
+    loki.withDataReplication +
     loki.withVolumeClaimTemplate {
       config+:: {
         local cfg = self,
@@ -41,6 +42,7 @@ local api = (import 'observatorium/observatorium-api.libsonnet');
         namespace: obs.config.namespace,
         commonLabels+:: obs.config.commonLabels,
         replicas: obs.config.replicas,
+        replicationFactor: 1,
       },
     },
 

--- a/environments/base/manifests/loki-compactor-statefulset.yaml
+++ b/environments/base/manifests/loki-compactor-statefulset.yaml
@@ -34,6 +34,7 @@ spec:
         - -log.level=error
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
+        - -distributor.replication-factor=1
         env:
         - name: S3_URL
           valueFrom:

--- a/environments/base/manifests/loki-config-map.yaml
+++ b/environments/base/manifests/loki-config-map.yaml
@@ -36,7 +36,6 @@ data:
           "heartbeat_timeout": "1m"
           "kvstore":
             "store": "memberlist"
-          "replication_factor": 1
       "max_transfer_retries": 0
     "ingester_client":
       "grpc_client_config":

--- a/environments/base/manifests/loki-distributor-deployment.yaml
+++ b/environments/base/manifests/loki-distributor-deployment.yaml
@@ -35,6 +35,7 @@ spec:
         - -log.level=error
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
+        - -distributor.replication-factor=1
         env:
         - name: S3_URL
           valueFrom:

--- a/environments/base/manifests/loki-ingester-statefulset.yaml
+++ b/environments/base/manifests/loki-ingester-statefulset.yaml
@@ -36,6 +36,7 @@ spec:
         - -log.level=error
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
+        - -distributor.replication-factor=1
         env:
         - name: S3_URL
           valueFrom:

--- a/environments/base/manifests/loki-querier-statefulset.yaml
+++ b/environments/base/manifests/loki-querier-statefulset.yaml
@@ -36,6 +36,7 @@ spec:
         - -log.level=error
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
+        - -distributor.replication-factor=1
         env:
         - name: S3_URL
           valueFrom:

--- a/environments/base/manifests/loki-query-frontend-deployment.yaml
+++ b/environments/base/manifests/loki-query-frontend-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         - -log.level=error
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
+        - -distributor.replication-factor=1
         env:
         - name: S3_URL
           valueFrom:

--- a/environments/dev/manifests/loki-compactor-statefulset.yaml
+++ b/environments/dev/manifests/loki-compactor-statefulset.yaml
@@ -34,6 +34,7 @@ spec:
         - -log.level=error
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
+        - -distributor.replication-factor=1
         env:
         - name: S3_URL
           valueFrom:

--- a/environments/dev/manifests/loki-config-map.yaml
+++ b/environments/dev/manifests/loki-config-map.yaml
@@ -36,7 +36,6 @@ data:
           "heartbeat_timeout": "1m"
           "kvstore":
             "store": "memberlist"
-          "replication_factor": 1
       "max_transfer_retries": 0
     "ingester_client":
       "grpc_client_config":

--- a/environments/dev/manifests/loki-distributor-deployment.yaml
+++ b/environments/dev/manifests/loki-distributor-deployment.yaml
@@ -35,6 +35,7 @@ spec:
         - -log.level=error
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
+        - -distributor.replication-factor=1
         env:
         - name: S3_URL
           valueFrom:

--- a/environments/dev/manifests/loki-ingester-statefulset.yaml
+++ b/environments/dev/manifests/loki-ingester-statefulset.yaml
@@ -36,6 +36,7 @@ spec:
         - -log.level=error
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
+        - -distributor.replication-factor=1
         env:
         - name: S3_URL
           valueFrom:

--- a/environments/dev/manifests/loki-querier-statefulset.yaml
+++ b/environments/dev/manifests/loki-querier-statefulset.yaml
@@ -36,6 +36,7 @@ spec:
         - -log.level=error
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
+        - -distributor.replication-factor=1
         env:
         - name: S3_URL
           valueFrom:

--- a/environments/dev/manifests/loki-query-frontend-deployment.yaml
+++ b/environments/dev/manifests/loki-query-frontend-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         - -log.level=error
         - -s3.url=$(S3_URL)
         - -s3.force-path-style=true
+        - -distributor.replication-factor=1
         env:
         - name: S3_URL
           valueFrom:


### PR DESCRIPTION
This PR exposes the `replication_factor` configuration option via `withReplicationFactor`. This way it enables overrides via OpenShift template parameters. Later cannot be replaced inside config map data blocks. Thus, the present implementation provides an override via container parameters.