### PR TITLE
Bump Loki version to v2.1.0

### DIFF
--- a/components/observatorium.libsonnet
+++ b/components/observatorium.libsonnet
@@ -91,7 +91,7 @@ local api = (import 'observatorium/observatorium-api.libsonnet');
     name: obs.config.name + '-' + cfg.commonLabels['app.kubernetes.io/name'],
     namespace: obs.config.namespace,
     commonLabels+:: obs.config.commonLabels,
-    version: '2.0.0',
+    version: '2.1.0',
     image: 'docker.io/grafana/loki:' + cfg.version,
     replicationFactor: 1,
     replicas: {

--- a/environments/base/manifests/loki-compactor-grpc-service.yaml
+++ b/environments/base/manifests/loki-compactor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-compactor-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-compactor-http-service.yaml
+++ b/environments/base/manifests/loki-compactor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-compactor-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-compactor-statefulset.yaml
+++ b/environments/base/manifests/loki-compactor-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-compactor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/base/manifests/loki-config-map.yaml
+++ b/environments/base/manifests/loki-config-map.yaml
@@ -105,6 +105,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/environments/base/manifests/loki-distributor-deployment.yaml
+++ b/environments/base/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/base/manifests/loki-distributor-grpc-service.yaml
+++ b/environments/base/manifests/loki-distributor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-distributor-http-service.yaml
+++ b/environments/base/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-gossip-ring.yaml
+++ b/environments/base/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-ingester-grpc-service.yaml
+++ b/environments/base/manifests/loki-ingester-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-ingester-http-service.yaml
+++ b/environments/base/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-ingester-statefulset.yaml
+++ b/environments/base/manifests/loki-ingester-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/base/manifests/loki-querier-grpc-service.yaml
+++ b/environments/base/manifests/loki-querier-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-querier-http-service.yaml
+++ b/environments/base/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-querier-statefulset.yaml
+++ b/environments/base/manifests/loki-querier-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/base/manifests/loki-query-frontend-deployment.yaml
+++ b/environments/base/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -40,7 +40,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/base/manifests/loki-query-frontend-grpc-service.yaml
+++ b/environments/base/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:

--- a/environments/base/manifests/loki-query-frontend-http-service.yaml
+++ b/environments/base/manifests/loki-query-frontend-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-query-frontend-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-compactor-grpc-service.yaml
+++ b/environments/dev/manifests/loki-compactor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-compactor-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-compactor-http-service.yaml
+++ b/environments/dev/manifests/loki-compactor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-compactor-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-compactor-statefulset.yaml
+++ b/environments/dev/manifests/loki-compactor-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-compactor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/dev/manifests/loki-config-map.yaml
+++ b/environments/dev/manifests/loki-config-map.yaml
@@ -105,6 +105,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/environments/dev/manifests/loki-distributor-deployment.yaml
+++ b/environments/dev/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/dev/manifests/loki-distributor-grpc-service.yaml
+++ b/environments/dev/manifests/loki-distributor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-distributor-http-service.yaml
+++ b/environments/dev/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-gossip-ring.yaml
+++ b/environments/dev/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-ingester-grpc-service.yaml
+++ b/environments/dev/manifests/loki-ingester-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-ingester-http-service.yaml
+++ b/environments/dev/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-ingester-statefulset.yaml
+++ b/environments/dev/manifests/loki-ingester-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/dev/manifests/loki-querier-grpc-service.yaml
+++ b/environments/dev/manifests/loki-querier-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-querier-http-service.yaml
+++ b/environments/dev/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-querier-statefulset.yaml
+++ b/environments/dev/manifests/loki-querier-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/dev/manifests/loki-query-frontend-deployment.yaml
+++ b/environments/dev/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -40,7 +40,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/dev/manifests/loki-query-frontend-grpc-service.yaml
+++ b/environments/dev/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:

--- a/environments/dev/manifests/loki-query-frontend-http-service.yaml
+++ b/environments/dev/manifests/loki-query-frontend-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-query-frontend-http
   namespace: observatorium
 spec:

--- a/environments/local/manifests/loki-compactor-grpc-service.yaml
+++ b/environments/local/manifests/loki-compactor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-compactor-grpc
   namespace: observatorium
 spec:

--- a/environments/local/manifests/loki-compactor-http-service.yaml
+++ b/environments/local/manifests/loki-compactor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-compactor-http
   namespace: observatorium
 spec:

--- a/environments/local/manifests/loki-compactor-statefulset.yaml
+++ b/environments/local/manifests/loki-compactor-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-compactor
   namespace: observatorium
 spec:
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/local/manifests/loki-config-map.yaml
+++ b/environments/local/manifests/loki-config-map.yaml
@@ -105,6 +105,6 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki
   namespace: observatorium

--- a/environments/local/manifests/loki-distributor-deployment.yaml
+++ b/environments/local/manifests/loki-distributor-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-distributor
   namespace: observatorium
 spec:
@@ -42,7 +42,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/local/manifests/loki-distributor-grpc-service.yaml
+++ b/environments/local/manifests/loki-distributor-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-distributor-grpc
   namespace: observatorium
 spec:

--- a/environments/local/manifests/loki-distributor-http-service.yaml
+++ b/environments/local/manifests/loki-distributor-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-distributor-http
   namespace: observatorium
 spec:

--- a/environments/local/manifests/loki-gossip-ring.yaml
+++ b/environments/local/manifests/loki-gossip-ring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-gossip-ring
   namespace: observatorium
 spec:

--- a/environments/local/manifests/loki-ingester-grpc-service.yaml
+++ b/environments/local/manifests/loki-ingester-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-ingester-grpc
   namespace: observatorium
 spec:

--- a/environments/local/manifests/loki-ingester-http-service.yaml
+++ b/environments/local/manifests/loki-ingester-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-ingester-http
   namespace: observatorium
 spec:

--- a/environments/local/manifests/loki-ingester-statefulset.yaml
+++ b/environments/local/manifests/loki-ingester-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-ingester
   namespace: observatorium
 spec:
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/local/manifests/loki-querier-grpc-service.yaml
+++ b/environments/local/manifests/loki-querier-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-querier-grpc
   namespace: observatorium
 spec:

--- a/environments/local/manifests/loki-querier-http-service.yaml
+++ b/environments/local/manifests/loki-querier-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-querier-http
   namespace: observatorium
 spec:

--- a/environments/local/manifests/loki-querier-statefulset.yaml
+++ b/environments/local/manifests/loki-querier-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-querier
   namespace: observatorium
 spec:
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/local/manifests/loki-query-frontend-deployment.yaml
+++ b/environments/local/manifests/loki-query-frontend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-query-frontend
   namespace: observatorium
 spec:
@@ -40,7 +40,7 @@ spec:
             secretKeyRef:
               key: endpoint
               name: loki-objectstorage
-        image: docker.io/grafana/loki:2.0.0
+        image: docker.io/grafana/loki:2.1.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/environments/local/manifests/loki-query-frontend-grpc-service.yaml
+++ b/environments/local/manifests/loki-query-frontend-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-query-frontend-grpc
   namespace: observatorium
 spec:

--- a/environments/local/manifests/loki-query-frontend-http-service.yaml
+++ b/environments/local/manifests/loki-query-frontend-http-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: observatorium-xyz
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: observatorium
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: observatorium-xyz-loki-query-frontend-http
   namespace: observatorium
 spec:


### PR DESCRIPTION
This PR addresses the pending update of Loki from v2.0.0 to v2.1.0.