### PR TITLE
Set requests for up test

### DIFF
--- a/tests/main.jsonnet
+++ b/tests/main.jsonnet
@@ -70,6 +70,11 @@ local metricsConfig = {
       memory: '128Mi',
       cpu: '500m',
     },
+    requests: {
+      memory: '128Mi',
+      cpu: '50m',
+    },
+
   },
   endpointType: 'metrics',
   writeEndpoint: 'http://%s.%s.svc.cluster.local:%d/api/metrics/v1/test/api/v1/receive' % [
@@ -132,6 +137,10 @@ local logsConfig = {
     limits: {
       memory: '128Mi',
       cpu: '500m',
+    },
+    requests: {
+      memory: '128Mi',
+      cpu: '50m',
     },
   },
   endpointType: 'logs',

--- a/tests/manifests/observatorium-up-logs-tls.yaml
+++ b/tests/manifests/observatorium-up-logs-tls.yaml
@@ -38,6 +38,9 @@ spec:
           limits:
             cpu: 500m
             memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
         volumeMounts:
         - mountPath: /mnt/tls
           name: tls

--- a/tests/manifests/observatorium-up-logs.yaml
+++ b/tests/manifests/observatorium-up-logs.yaml
@@ -37,6 +37,9 @@ spec:
           limits:
             cpu: 500m
             memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
         volumeMounts:
         - mountPath: /var/shared
           name: shared

--- a/tests/manifests/observatorium-up-metrics-tls.yaml
+++ b/tests/manifests/observatorium-up-metrics-tls.yaml
@@ -37,6 +37,9 @@ spec:
           limits:
             cpu: 500m
             memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
         volumeMounts:
         - mountPath: /mnt/tls
           name: tls

--- a/tests/manifests/observatorium-up-metrics.yaml
+++ b/tests/manifests/observatorium-up-metrics.yaml
@@ -36,6 +36,9 @@ spec:
           limits:
             cpu: 500m
             memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
         volumeMounts:
         - mountPath: /var/shared
           name: shared


### PR DESCRIPTION
If a Container specifies its own CPU limit, but does not specify a CPU request, Kubernetes automatically assigns a CPU request that matches the limit. Set requests for up smaller than limit to ensure the tests can be passed in https://github.com/observatorium/operator/pull/52.

Signed-off-by: clyang82 <chuyang@redhat.com>